### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-02-24
+
+### Changed
+
+- Moved select `devDependencies` needed upstream to `dependencies`
+
 ## [1.0.0] - 2021-02-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-forcir",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "homepage": "https://github.com/forcir/eslint-config-forcir",
   "bugs": {
@@ -27,11 +27,9 @@
     "prepare": "husky install",
     "test": "jest --passWithNoTests"
   },
-  "devDependencies": {
+  "dependencies": {
     "@typescript-eslint/eslint-plugin": "5.12.1",
     "@typescript-eslint/parser": "5.12.1",
-    "eslint": "8.9.0",
-    "eslint-config-forcir": "0.0.1-canary.1",
     "eslint-config-prettier": "8.4.0",
     "eslint-plugin-import": "2.25.4",
     "eslint-plugin-jest": "26.1.1",
@@ -39,7 +37,11 @@
     "eslint-plugin-promise": "6.0.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
-    "eslint-plugin-unicorn": "41.0.0",
+    "eslint-plugin-unicorn": "41.0.0"
+  },
+  "devDependencies": {
+    "eslint": "8.9.0",
+    "eslint-config-forcir": "0.0.1-canary.1",
     "husky": "7.0.4",
     "jest": "27.5.1",
     "lint-staged": "12.3.4",


### PR DESCRIPTION
Moved select `devDependencies` needed upstream to `dependencies`